### PR TITLE
Allow bounded zero RPC spacing

### DIFF
--- a/tests/launch_gate_test.mjs
+++ b/tests/launch_gate_test.mjs
@@ -30,6 +30,10 @@ gate = new Gate(base);
 replies.push((_request, init) => { redirectPolicy = init.redirect; return { status: 200, text: async () => JSON.stringify({ jsonrpc: "2.0", id: 1, result: "ok" }) }; });
 ok(await gate.call("eth_blockNumber", []) === "ok" && redirectPolicy === "error", "refuses to follow redirects for an endpoint that may carry a path credential");
 
+gate = new Gate({ ...base, spacingMs: 0, logsSpacingMs: 0 });
+replies.push({ result: "zero-spacing" });
+ok(await gate.call("eth_blockNumber", []) === "zero-spacing", "accepts an intentional zero spacing while every request remains concurrency-bound");
+
 for (const [label, body] of [
   ["wrong version", { jsonrpc: "1.0", id: 1, result: 7 }],
   ["wrong id", { jsonrpc: "2.0", id: 2, result: 7 }],
@@ -112,6 +116,9 @@ ok(message.includes("rpc error -32000") && !message.includes("endpoint-secret-se
 let badConfig = false;
 try { new Gate({ ...base, requestTimeoutMs: 0 }); } catch (error) { badConfig = error.message.includes("configuration"); }
 ok(badConfig, "refuses an unbounded request deadline");
+badConfig = false;
+try { new Gate({ ...base, spacingMs: -1 }); } catch (error) { badConfig = error.message.includes("configuration"); }
+ok(badConfig, "refuses a negative request spacing");
 
 console.log(`launch gate test: ${checks} checks, ${failures} failure(s)`);
 process.exit(failures ? 1 : 0);

--- a/tools/launch/rpc.mjs
+++ b/tools/launch/rpc.mjs
@@ -5,6 +5,7 @@
 // awaited, and a successful reply must be JSON-RPC 2.0 with the exact request id. The request names itself in its user agent: the endpoint's
 // edge refuses anonymous library signatures (Cloudflare 1010).
 const positive = value => Number.isSafeInteger(value) && value > 0;
+const nonnegative = value => Number.isSafeInteger(value) && value >= 0;
 
 const timeoutError = () => {
   const error = new Error("request deadline exceeded");
@@ -112,7 +113,7 @@ const redactEndpoint = (text, url) => {
 
 export class Gate {
   constructor({ url, inFlight = 2, spacingMs = 600, logsSpacingMs = 1500, cooldownMs = 3000, maxCooldownMs = 60000, maxRetries = 10, requestTimeoutMs = 60000, maxResponseBytes = 64 * 1024 * 1024, log = () => {} } = {}) {
-    if (typeof url !== "string" || !url || !positive(inFlight) || !positive(spacingMs) || !positive(logsSpacingMs) || !positive(cooldownMs) || !positive(maxCooldownMs) || !Number.isSafeInteger(maxRetries) || maxRetries < 0 || !positive(requestTimeoutMs) || !positive(maxResponseBytes) || typeof log !== "function") {
+    if (typeof url !== "string" || !url || !positive(inFlight) || !nonnegative(spacingMs) || !nonnegative(logsSpacingMs) || !positive(cooldownMs) || !positive(maxCooldownMs) || !Number.isSafeInteger(maxRetries) || maxRetries < 0 || !positive(requestTimeoutMs) || !positive(maxResponseBytes) || typeof log !== "function") {
       throw new Error("RPC gate configuration is invalid");
     }
     Object.assign(this, { url, inFlight, spacingMs, logsSpacingMs, cooldownMs, maxCooldownMs, maxRetries, requestTimeoutMs, maxResponseBytes, log });


### PR DESCRIPTION
Preserves the hardened Gate while accepting an intentional zero request spacing used by the chain Worker. Concurrency, request deadlines, response bounds, strict JSON-RPC correlation, and redirect refusal remain enforced; negative spacing still fails closed. Adds positive zero-spacing and negative-spacing regressions.