### PR TITLE
Make RPC redirect handling Workers-compatible

### DIFF
--- a/tests/launch_gate_test.mjs
+++ b/tests/launch_gate_test.mjs
@@ -28,7 +28,7 @@ ok(gate.stats.calls === 1 && gate.stats.retries === 0 && gate.stats.otherErrors 
 let redirectPolicy = null;
 gate = new Gate(base);
 replies.push((_request, init) => { redirectPolicy = init.redirect; return { status: 200, text: async () => JSON.stringify({ jsonrpc: "2.0", id: 1, result: "ok" }) }; });
-ok(await gate.call("eth_blockNumber", []) === "ok" && redirectPolicy === "error", "refuses to follow redirects for an endpoint that may carry a path credential");
+ok(await gate.call("eth_blockNumber", []) === "ok" && redirectPolicy === "manual", "refuses to follow redirects with a policy supported by Cloudflare Workers");
 
 gate = new Gate({ ...base, spacingMs: 0, logsSpacingMs: 0 });
 replies.push({ result: "zero-spacing" });

--- a/tools/launch/rpc.mjs
+++ b/tools/launch/rpc.mjs
@@ -143,7 +143,9 @@ export class Gate {
     const timer = setTimeout(() => controller.abort(), this.requestTimeoutMs);
     try {
       const id = ++this.id;
-      const r = await withAbort(fetch(this.url, { method: "POST", redirect: "error", headers: { "content-type": "application/json", "user-agent": "lintcha-launch-collector/0.1 (+https://lintcha.com)" }, body: JSON.stringify({ jsonrpc: "2.0", id, method: task.method, params: task.params }), signal: controller.signal }), controller.signal);
+      // Cloudflare Workers does not support redirect: "error". Manual mode is portable and preserves the
+      // no-follow boundary: a redirect stays visible as a non-200 response instead of forwarding path credentials.
+      const r = await withAbort(fetch(this.url, { method: "POST", redirect: "manual", headers: { "content-type": "application/json", "user-agent": "lintcha-launch-collector/0.1 (+https://lintcha.com)" }, body: JSON.stringify({ jsonrpc: "2.0", id, method: task.method, params: task.params }), signal: controller.signal }), controller.signal);
       status = r.status;
       if (status === 429) cancelBestEffort(r.body);
       else {


### PR DESCRIPTION
Cloudflare Workers does not support redirect:error. Use redirect:manual to keep redirects visible as non-200 responses without following credential-bearing paths, and update the focused gate assertion.\n\nTest: node tests/launch_gate_test.mjs